### PR TITLE
Fix LINQPad sample

### DIFF
--- a/linqpad-samples/Examples/Spritesheet Cutter.linq
+++ b/linqpad-samples/Examples/Spritesheet Cutter.linq
@@ -52,7 +52,7 @@ async Task Main()
 									x * config.SpriteWidth,
 									y * config.SpriteHeight,
 									config.SpriteWidth,
-									config.SpriteHeight).Do(spriteRects.Add)
+									config.SpriteHeight).DoSingle(spriteRects.Add)
 						), $"{x},{y}"))
 				.ToList();
 				
@@ -115,6 +115,12 @@ public static class Ext
 				g.DrawRectangle(p, r);
 
 		return b;
+	}
+	
+	public static T DoSingle<T>(this T item, Action<T> action)
+	{
+		action(item);
+		return item;
 	}
 	
 	public static IEnumerable<T> Do<T>(this IEnumerable<T> items, Action<T> action)


### PR DESCRIPTION
Tried running the samples in LINQPad 6.10. This is amazing stuff!

Found one broken that won't compile and run, but the fix is simple. The `Do()` extension method is expecting an `IEnumerable<T>`, but the `new Rectangle()` on line 51 is a single item. I tried to come up with some clever overload or changing behavior based on type checking, but this seemed simpler, and certainly works.